### PR TITLE
fix: calendar display quota to match overview and alternative dates

### DIFF
--- a/app/Http/Controllers/Api/CampaignController.php
+++ b/app/Http/Controllers/Api/CampaignController.php
@@ -397,6 +397,7 @@ class CampaignController extends Controller
                 ],
                 'monthly_summary' => [
                     'total_campaigns' => collect($data['daily_breakdown'])->sum('campaign_summary.total_campaigns'),
+                    'cancelled_campaigns' => collect($data['daily_breakdown'])->sum('campaign_summary.cancelled_campaigns'),
                     'sent_campaigns' => collect($data['daily_breakdown'])->sum('campaign_summary.sent_campaigns'),
                     'pending_campaigns' => collect($data['daily_breakdown'])->sum('campaign_summary.pending_campaigns'),
                     'approved_campaigns' => collect($data['daily_breakdown'])->sum('campaign_summary.approved_campaigns'),


### PR DESCRIPTION
### 🔧 Hotfix: Perbaikan Tampilan Kuota di Kalender

**Deskripsi:**
Bug ini menyebabkan tampilan kuota di kalender tidak konsisten dengan data dari `alternative_dates` dan `overview`.

### ✅ Perbaikan yang dilakukan:
- **Equal quota mode** sekarang akan menampilkan `available_quota: 1` (sesuai dengan `alternative_dates`)
- **Group quota mode** sekarang akan menampilkan `available_quota: 3` (kuota grup)

### 🔍 Hasil yang diharapkan:
Tampilan kalender akan menampilkan kuota yang **konsisten** dengan:
- Informasi `alternative_dates`
- Data `overview` dari endpoint API

### 📎 Branch:
`hotfix/fix-calendar-quota-display` → `dev`

---

Mohon review dan approval 🙏
